### PR TITLE
Drop pydantic v1 and use most recent validators

### DIFF
--- a/src/stratocaster/base/models.py
+++ b/src/stratocaster/base/models.py
@@ -3,4 +3,5 @@ from gufe.settings.models import SettingsBaseModel
 
 class StrategySettings(SettingsBaseModel):
     """Base class for Strategy settings."""
+
     pass

--- a/src/stratocaster/base/strategy.py
+++ b/src/stratocaster/base/strategy.py
@@ -8,6 +8,7 @@ from .models import StrategySettings
 
 TProtocolResult = TypeVar("TProtocolResult", bound=ProtocolResult)
 
+
 class StrategyResult(GufeTokenizable):
     """Results produced by a Strategy."""
 


### PR DESCRIPTION
This PR removes the use of v1 style validators.