### PR TITLE
Better handling of zero and None weights in `resolve`

### DIFF
--- a/src/stratocaster/base/strategy.py
+++ b/src/stratocaster/base/strategy.py
@@ -33,9 +33,21 @@ class StrategyResult(GufeTokenizable):
 
     def resolve(self) -> dict[GufeKey, float | None]:
         """Get normalized proposal weights relative to all non-None Transformation weights."""
-        weight_sum = sum(
-            [weight for weight in self._weights.values() if weight is not None]
-        )
+        non_none_weights = [
+            weight for weight in self._weights.values() if weight is not None
+        ]
+
+        if not non_none_weights:
+            return self.weights
+
+        weight_sum = sum(non_none_weights)
+        if weight_sum == 0:
+            raise ValueError(
+                "Cannot resolve weights: sum of non-None weights is zero. "
+                "This is likely a bug in the Strategy implementation. "
+                "Please raise an issue at https://github.com/OpenFreeEnergy/stratocaster/issues"
+            )
+
         normalized_weights = {
             key: weight / weight_sum if weight is not None else None
             for key, weight in self._weights.items()

--- a/src/stratocaster/tests/test_strategy_base.py
+++ b/src/stratocaster/tests/test_strategy_base.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gufe import AlchemicalNetwork, ProtocolResult
 from gufe.tokenization import GufeKey
 
@@ -27,6 +29,19 @@ class TestStrategyResult:
         """Resolve produces normalized weights for all non-None values."""
         res = self.result.resolve()
         assert 1 == sum([value for _, value in res.items() if value is not None])
+
+    def test_resolve_no_zero_division(self):
+        all_zero_weights = StrategyResult(
+            {key: 0 for key, _ in self.result.weights.items()}
+        )
+        all_none_weights = StrategyResult(
+            {key: None for key, _ in self.result.weights.items()}
+        )
+
+        with pytest.raises(ValueError):
+            _ = all_zero_weights.resolve()
+
+        _ = all_none_weights.resolve()
 
 
 class DummyStrategySettings(StrategySettings):


### PR DESCRIPTION
`resolve` should explicitly handle the events of all `None` weights and all `0` weights.